### PR TITLE
Fixed section title parent frame

### DIFF
--- a/wurst/ItemShopMenu.wurst
+++ b/wurst/ItemShopMenu.wurst
@@ -90,7 +90,11 @@ public class ItemShop
   function addSection(string title)
     tableLayout
     ..row()
-    ..add(p(title))..padTop(SECTION_TOP_SPACING)..padBot(SECTION_BOTTOM_SPACING)
+    ..add(
+      createFrame("p", tableLayout.baseFrame, 0, 0)
+      ..setText(title)
+      ..setTextAlignment(TEXT_JUSTIFY_CENTER, TEXT_JUSTIFY_CENTER)
+      )..padTop(SECTION_TOP_SPACING)..padBot(SECTION_BOTTOM_SPACING)
     ..row()
 
     currentRowItems = 0


### PR DESCRIPTION
Changed section title parent from GAME_UI to table layout's base frame, so for example hero ability tooltips will be shown on top of section title.
